### PR TITLE
Add reference docs for CLI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,4 @@
 - [Get Started](./get-started.md)
 - [Using in test tools](./using-test-tools.md)
 - [Workflow Syntax](./workflow-syntax.md)
+- [CLI Reference](./cli-reference.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Step CI Documentation
 
 - [Get Started](./get-started.md)
-- [Using in test tools](./using-test-tools.md)
-- [Workflow Syntax](./workflow-syntax.md)
 - [CLI Reference](./cli-reference.md)
+- [Workflow Syntax](./workflow-syntax.md)
+- [Using in Test Tools](./using-test-tools.md)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,18 +1,15 @@
-# StepCI CLI reference
-The following documents evety command and flag avaliable for use in StepCI's command-line interface.
+# CLI reference
+The following documents every command and flag available for use in StepCI's command-line interface.
 
-With the CLI you can:
-- Run workflows
-
-Follow the [getting started guide](https://github.com/stepci/stepci/blob/main/docs/get-started.md) for setup instructions
+Follow the [getting started guide](../get-started.md) for setup instructions
 
 ## Synopsis
 ---
 The `stepci` command can be called once installed and is the main command for the CLI.
 
-The primary method to execute StepCI workflows is `stepci run [command]`
+The primary method to execute workflows is `stepci run [command]`
 
-When `stepci` is called with the `--help` option a list of avaliable commands and options will be displayed:
+When `stepci` is called with the `--help` option, a list of avaliable commands and options will be displayed:
 ```console
 $ stepci --help
 stepci [command]
@@ -28,12 +25,12 @@ Options:
 ## Commands
 ---
 ### `run [workflow]`
-The `run ` command allows you to execute a specified workflow
+The `run ` command lets you execute a specified workflow
 
 #### **Arguments**
 | Argument | Required | Description |
 |-|-|-|
-| workflow | Yes | Specify the path to a stepci workflow |
+| workflow | Yes | Specify the path to a workflow |
 <br>
 
 #### **Options**
@@ -44,7 +41,7 @@ The `run ` command allows you to execute a specified workflow
 <br>
 
 #### **Examples**
-Run test workflow to return the status of [example.com](https://example.com)
+Run example workflow to return the status of [example.com](https://example.com)
 ```console
 $ stepci run ./examples/status.yml
 
@@ -65,7 +62,7 @@ Status
 ## Options
 ---
 ### `--help`
-Outputs the help menu for the main `stepci` comamnd
+Outputs the help menu for the main `stepci` command
 
 #### **Examples**
 ```console
@@ -81,7 +78,7 @@ Options:
 ```
 
 ### `--version`
-Outputs the current version of stepci installed
+Outputs the version currently installed
 
 #### **Examples**
 ```console

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -25,7 +25,7 @@ Options:
 ## Commands
 ---
 ### `run [workflow]`
-The `run ` command lets you execute a specified workflow
+The `run` command lets you execute a specified workflow
 
 #### **Arguments**
 | Argument | Required | Description |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,90 @@
+# StepCI CLI reference
+The following documents evety command and flag avaliable for use in StepCI's command-line interface.
+
+With the CLI you can:
+- Run workflows
+
+Follow the [getting started guide](https://github.com/stepci/stepci/blob/main/docs/get-started.md) for setup instructions
+
+## Synopsis
+---
+The `stepci` command can be called once installed and is the main command for the CLI.
+
+The primary method to execute StepCI workflows is `stepci run [command]`
+
+When `stepci` is called with the `--help` option a list of avaliable commands and options will be displayed:
+```console
+$ stepci --help
+stepci [command]
+
+Commands:
+  run [workflow]  run workflow
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+  ```
+
+## Commands
+---
+### `run [workflow]`
+The `run ` command allows you to execute a specified workflow
+
+#### **Arguments**
+| Argument | Required | Description |
+|-|-|-|
+| workflow | Yes | Specify the path to a stepci workflow |
+<br>
+
+#### **Options**
+| Options | Required | Description |
+|-|-|-|
+| --help | No | Outputs the help text for `stepci run` |
+| --version | No | Outputs the current stepci version |
+<br>
+
+#### **Examples**
+Run test workflow to return the status of [example.com](https://example.com)
+```console
+$ stepci run ./examples/status.yml
+
+
+Request
+
+ GET  https://example.com/  200 OK 
+
+Checks
+
+Status
+✔ 200
+
+
+✔ Status Check (./examples/status.yml) passed in 0.526s
+```
+
+## Options
+---
+### `--help`
+Outputs the help menu for the main `stepci` comamnd
+
+#### **Examples**
+```console
+$ stepci --help
+stepci [command]
+
+Commands:
+  run [workflow]  run workflow
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+```
+
+### `--version`
+Outputs the current version of stepci installed
+
+#### **Examples**
+```console
+$ stepci --version
+2.1.0
+```


### PR DESCRIPTION
Issue: #8 

I have tried to reference all the current CLI and build a format in line with my preferences from parts of the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference), [Prisma CLI](https://www.prisma.io/docs/reference/api-reference/command-reference) and [Stripe CLI](https://stripe.com/docs/cli) reference guides. 

Hopefully, it covers everything and is in a style that is helpful and easy to follow

If you would like any changes made or if I have missed anything do let me know
