### PR TITLE
Add support for environment variables in command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,8 @@ function renderStep (step: StepResult) {
 }
 
 // Load workflow files
-function loadWorkflow (path: string, env?: EnvironmentVariables) {
-  runFromFile(path, { ee, env })
+function loadWorkflow (path: string, envOverride?: EnvironmentVariables) {
+  runFromFile(path, { ee, envOverride })
 }
 
 yargs(hideBin(process.argv))

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,8 +48,8 @@ function renderStep (step: StepResult) {
 }
 
 // Load workflow files
-function loadWorkflow (path: string, envOverride?: EnvironmentVariables) {
-  runFromFile(path, { ee, envOverride })
+function loadWorkflow (path: string, env?: EnvironmentVariables) {
+  runFromFile(path, { ee, env })
 }
 
 yargs(hideBin(process.argv))


### PR DESCRIPTION
According to feature request https://github.com/stepci/stepci/issues/9 this PR adds support for environment variables set as argument. The arguments will override the settings in the workflow file.