### PR TITLE
Add support for secret variables in command

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -42,7 +42,8 @@ The `run` command lets you execute a specified workflow
 |-|-|-|
 | --help | No | Outputs the help text for `stepci run` |
 | --version | No | Outputs the current version |
-| -e [--env] | No | Supply environment variables |
+| -e [--env] | No | Supply environment variables (can be defined multiple times) |
+| -s [--secret] | No | Supply secret variables (can be defined multiple times) |
 
 #### **Examples**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import { EnvironmentVariables, runFromFile, StepResult, TestResult, WorkflowResult, HTTPStepRequest, HTTPStepResponse, gRPCStepRequest } from '@stepci/runner'
+import { EnvironmentVariables, gRPCStepRequest, HTTPStepRequest, HTTPStepResponse, runFromFile, StepResult, TestResult, WorkflowResult } from '@stepci/runner'
 import exit from 'exit'
 import chalk from 'chalk'
 import os from 'os'
@@ -12,6 +12,7 @@ import ci from 'ci-info'
 import isDocker from 'is-docker'
 import Conf from 'conf'
 import { labels } from './labels.json'
+import { checkOptionalEnvArrayFormat, parseEnvArray } from './lib/utils'
 
 const config = new Conf()
 const posthog = new PostHog(
@@ -86,9 +87,14 @@ function renderStep (step: StepResult) {
   }
 }
 
+type LoadWorkflowOptions = {
+  env?: EnvironmentVariables
+  secrets?: EnvironmentVariables
+}
+
 // Load workflow files
-function loadWorkflow (path: string, env?: EnvironmentVariables) {
-  runFromFile(path, { ee, env })
+function loadWorkflow (path: string, options: LoadWorkflowOptions = {}) {
+  runFromFile(path, { ...options, ee })
 }
 
 yargs(hideBin(process.argv))
@@ -106,16 +112,29 @@ yargs(hideBin(process.argv))
         describe: 'env variables to use',
         type: 'string'
       })
-      .check((argv) => {
-        if (argv.e?.length && !argv.e.every(env => env.match(/^(\w+=.+)$/))) {
+      .option('s', {
+        alias: 'secret',
+        array: true,
+        demandOption: false,
+        describe: 'secret variables to use',
+        type: 'string'
+      })
+      .check(({ e: envs, s: secrets }) => {
+        if (checkOptionalEnvArrayFormat(envs)) {
           throw new Error('env variables have wrong format, use `env=VARIABLE`.')
+        }
+
+        if (checkOptionalEnvArrayFormat(secrets)) {
+          throw new Error('secret variables have wrong format, use `secret=VARIABLE`.')
         }
 
         return true;
       })
   }, (argv) => {
-    const parsedEnv: EnvironmentVariables = Object.fromEntries(argv.e?.map(opt => opt.split('=')) ?? [])
-    loadWorkflow(argv.workflow, parsedEnv)
+    loadWorkflow(argv.workflow, {
+      env: parseEnvArray(argv.e),
+      secrets: parseEnvArray(argv.s)
+    })
   })
   .parse()
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,9 @@
+import { EnvironmentVariables } from "@stepci/runner";
+
+export const checkEnvFormat = (str: string) => str.match(/^(\w+=.+)$/)
+
+export const checkOptionalEnvArrayFormat = (envs?: string[]) =>
+  envs?.length && !envs.every(checkEnvFormat)
+
+export const parseEnvArray = (env?: string[]): EnvironmentVariables =>
+  Object.fromEntries(env?.map((opt) => opt.split("=")) ?? [])

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,12 @@
-import { EnvironmentVariables } from "@stepci/runner";
+import { EnvironmentVariables } from '@stepci/runner';
 
+// Check if env format matches the convention e.g. `variable=VARIABLE`
 export const checkEnvFormat = (str: string) => str.match(/^(\w+=.+)$/)
 
+// Check if all optional env variables match the required format
 export const checkOptionalEnvArrayFormat = (envs?: string[]) =>
   envs?.length && !envs.every(checkEnvFormat)
 
+// Parse every entry in optional env array to a key value pair and return as object
 export const parseEnvArray = (env?: string[]): EnvironmentVariables =>
-  Object.fromEntries(env?.map((opt) => opt.split("=")) ?? [])
+  Object.fromEntries(env?.map((opt) => opt.split('=')) ?? [])


### PR DESCRIPTION
According to feature request https://github.com/stepci/stepci/issues/35 this PR adds support for secret variables set as argument.

TODO:

- [ ]  secret variable is still displayed on cli, e.g. using the examples/status.yml and replacing `env.host` with `secret.host`

Secrets should be obfuscated in runner and not returned as plain values in the result object.