### PR TITLE
Show help command when stepci is called with no arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ yargs(hideBin(process.argv))
     const parsedEnv: EnvironmentVariables = Object.fromEntries(argv.e?.map(opt => opt.split('=')) ?? [])
     loadWorkflow(argv.workflow, parsedEnv)
   })
+  .demandCommand()
   .parse()
 
 posthog.shutdown()


### PR DESCRIPTION
Closes #21

There is also an option to add a custom message instead of default one: `Not enough non-option arguments: got 0, need at least 1`. But I don't know if it is needed or not.