### PR TITLE
add default commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-import yargs from 'yargs'
+import yargs, {showHelp} from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { EnvironmentVariables, runFromFile, TestResult, WorkflowResult } from '@stepci/runner'
 import { generateWorkflowFile, GenerateWorkflowOptions } from '@stepci/plugin-openapi'
 import exit from 'exit'
 import chalk from 'chalk'
 import { EventEmitter } from 'node:events'
+import { stepCiDefaultText } from './lib/constants'
 import { checkOptionalEnvArrayFormat, parseEnvArray } from './lib/utils'
 import { renderStep, renderSummary, renderStepSummary, renderFeedbackMessage } from './lib/render'
 import { sendAnalyticsEvent } from './lib/analytics'
@@ -38,6 +39,7 @@ function loadWorkflow (path: string, options: LoadWorkflowOptions = {}) {
 }
 
 yargs(hideBin(process.argv))
+  .scriptName("")
   .command('run [workflow]', 'run workflow', (yargs) => {
     return yargs
       .positional('workflow', {
@@ -127,6 +129,12 @@ yargs(hideBin(process.argv))
     console.log(`${chalk.greenBright('Success!')} The workflow file can be found at ${argv.path}`)
     renderFeedbackMessage()
   })
+  .command(['$0'], false, () => {}, async () => {
+    console.log(stepCiDefaultText)
+    showHelp()
+  })
+  .help(false)
+  .version(false)
   .parse()
 
 sendAnalyticsEvent()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import yargs, {showHelp} from 'yargs'
+import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 import { EnvironmentVariables, runFromFile, TestResult, WorkflowResult } from '@stepci/runner'
 import { generateWorkflowFile, GenerateWorkflowOptions } from '@stepci/plugin-openapi'
@@ -39,7 +39,6 @@ function loadWorkflow (path: string, options: LoadWorkflowOptions = {}) {
 }
 
 yargs(hideBin(process.argv))
-  .scriptName("")
   .command('run [workflow]', 'run workflow', (yargs) => {
     return yargs
       .positional('workflow', {
@@ -131,10 +130,7 @@ yargs(hideBin(process.argv))
   })
   .command(['$0'], false, () => {}, async () => {
     console.log(stepCiDefaultText)
-    showHelp()
   })
-  .help(false)
-  .version(false)
   .parse()
 
 sendAnalyticsEvent()

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,6 @@
+const appVersion = require('../../package.json').version;
+
+export const stepCiDefaultText = `Weclome to StepCI! ( Version ${appVersion} )
+StepCI use Anonymous data collection.
+if you want to disable it, please set environment variable STEPCI_DISABLE_ANALYTICS=true.`
+

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,8 @@
 const appVersion = require('../../package.json').version;
 
-export const stepCiDefaultText = `Weclome to StepCI! ( Version ${appVersion} )
-StepCI use Anonymous data collection.
-if you want to disable it, please set environment variable STEPCI_DISABLE_ANALYTICS=true.`
+export const stepCiDefaultText = `
+Weclome to StepCI! ( Version ${appVersion} )
 
+StepCI use Anonymous data collection.
+if you want to disable it, please set environment variable STEPCI_DISABLE_ANALYTICS=true.
+`


### PR DESCRIPTION
Hello! I Implement some default commands.

### it can shows

- show stepci version
- inform STEPCI_DISABLE_ANALYTICS variables
- show available commands.

and, it shows on my terminal like this.

![image](https://user-images.githubusercontent.com/31124212/201139902-199e7b18-e32a-4f84-9ed1-758290103a6b.png)

you can easily change default message in `src/lib/constants.ts` files.

### This is what changes.

*  I disable default yargs command `version`, and `help`.
    *  because the default command always shows help and versions. i think we don't need that commands.
* I set scriptname `""`
   * there is two reason.
   * first reason is yargs's `showHelp()` method show script name.
       *  so, if i set scriptName to "stepci", the default message show like this. (sadly, yargs can't disable that options)
       ![image](https://user-images.githubusercontent.com/31124212/201142007-bc21a83e-001e-4fd4-9c5f-904052a1bca7.png)
       * this looks confuse to me.
   * second reason is if we use yargs's `gethelp()` method, it is difficult to control order of  messages. because `gethelp()` method return promise.
   * if i use this code..
```typescript
...
  .command(['$0'], false, () => {}, async () => {
    console.log(stepCiDefaultText)
    await console.log(await getHelp())
    showHelp()
  })
  .help(false)
  .version(false)
  .parse()

sendAnalyticsEvent()
````
   * then the output look like this...
![image](https://user-images.githubusercontent.com/31124212/201142835-9ec994a8-68c7-4f9a-91f8-dd3567aa9046.png)

surely, i can handle it by moving `sendAnalyticsEvent()` function. but i think it make unintuitive code. so, I decided not to.

---

If there's anything I can do to help, I'll work on it more! thanks 😄

Closes https://github.com/stepci/stepci/issues/21