### PR TITLE
Build arm64 Docker Image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,16 +6,21 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Setup env
       run: |
         echo CONTAINER_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}:${GITHUB_REF#refs/*/} >> $GITHUB_ENV
         echo CONTAINER_IMAGE_LATEST=ghcr.io/${GITHUB_REPOSITORY,,}:latest >> $GITHUB_ENV
-    - name: Build
-      run: docker build -t $CONTAINER_IMAGE -t $CONTAINER_IMAGE_LATEST .
     - name: Login
       run: docker login -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}} ghcr.io
-    - name: Publish
-      run: |
-        docker push $CONTAINER_IMAGE
-        docker push $CONTAINER_IMAGE_LATEST
+    - name: Build and push
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ env.CONTAINER_IMAGE }},${{ env.CONTAINER_IMAGE_LATEST }}


### PR DESCRIPTION
This PR will build and publish an arm64 Docker image using the QEMU runner.

In my tests, build time increased from ~60s to ~120s, which seems like a reasonable trade-off.