### PR TITLE
CLI Docs: Options *MUST* follow positional arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Step CI is an open-source API Quality Assurance framework
 3. Run the workflow
 
     ```
-    stepci run workflow.yml
+    stepci run workflow.yml -e host=example.org
     ```
 
     ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -18,8 +18,8 @@ When `stepci` is called with the `--help` option, a list of avaliable commands a
 stepci [command]
 
 Commands:
-  stepci run [workflow]          run workflow
-  stepci generate [spec] [path]  generate workflow from OpenAPI spec
+  stepci run [workflow] [options] run workflow
+  stepci generate [spec] [path]   generate workflow from OpenAPI spec
 
 Options:
   --help     Show help                                                 [boolean]
@@ -51,7 +51,7 @@ Success! The workflow file can be found at workflow.yml
 Enter npx stepci run workflow.yml to run it
 ```
 
-### `run [workflow]`
+### `run [workflow] [options]`
 
 The `run` command lets you run a specified workflow
 
@@ -75,7 +75,7 @@ The `run` command lets you run a specified workflow
 Run example workflow located at `examples/status.yml`
 
 ```
-stepci run examples/status.yml
+stepci run examples/status.yml -e host=localhost
 ```
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ ee.on('workflow:result', ({ result }: WorkflowResult) => {
 })
 
 yargs(hideBin(process.argv))
-  .command('run [workflow] [options]', 'run workflow', (yargs) => {
+  .command('run [workflow]', 'run workflow', (yargs) => {
     return yargs
       .positional('workflow', {
         describe: 'workflow file path',

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ ee.on('workflow:result', ({ result }: WorkflowResult) => {
 })
 
 yargs(hideBin(process.argv))
-  .command('run [workflow]', 'run workflow', (yargs) => {
+  .command('run [workflow] [options]', 'run workflow', (yargs) => {
     return yargs
       .positional('workflow', {
         describe: 'workflow file path',
@@ -76,7 +76,7 @@ yargs(hideBin(process.argv))
       })
       .check(({ e: envs, s: secrets }) => {
         if (checkOptionalEnvArrayFormat(envs)) {
-          throw new Error('env variables have wrong format, use `env=VARIABLE`.')
+          throw new Error(`env variables have wrong format, use \`env=VARIABLE\`. Found: ${envs}`)
         }
 
         if (checkOptionalEnvArrayFormat(secrets)) {


### PR DESCRIPTION
Update documentation to make it clear that cli options cannot appear before workflow file.

The following will not work:

    stepci run -e host=localhost workflow.yaml

Options must be specified *after* positional arguments (e.g. workflow file):

    stepci run workflow.yaml -e host=localhost

I found zero documentation on using cli switches with stepci so thought it would be nice to have some.