### PR TITLE
Update editor-integration.md

### DIFF
--- a/docs/guides/editor-integration.md
+++ b/docs/guides/editor-integration.md
@@ -11,13 +11,13 @@ Note: VS Code users may require to install Red Hat's [YAML extension](https://ma
 ```json
 {
   "yaml.completion": true,
-  "json.schemas": {
+  "yaml.schemas": {
     "https://raw.githubusercontent.com/stepci/stepci/main/schema.json": "*.stepci.yml"
   }
 }
 ```
 
-After that you should be able to see completions for **YAML files** starting with `.stepci.yml`
+After that you should be able to see completions for **YAML files** ending with `.stepci.yml`
 
 **JSON Completions**
 
@@ -35,4 +35,4 @@ After that you should be able to see completions for **YAML files** starting wit
 }
 ```
 
-After that you should be able to see completions for **JSON files** starting with `.stepci.json`
+After that you should be able to see completions for **JSON files** ending with `.stepci.json`


### PR DESCRIPTION
I updated followings.

Fix vscode settings.json of yaml completion.
Fix description of filename
The document's example seems to describe "files end with .stepci{.json,yaml}", but the document described "files starting with".