### PR TITLE
Avoid red and green for transferred data arrows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ renderAnalyticsMessage()
 
 const ee = new EventEmitter()
 ee.on('test:result', (test: TestResult) => {
-  console.log(`${(test.passed ? chalk.bgGreenBright(' PASS ') : chalk.bgRedBright(' FAIL '))} ${chalk.bold(test.name || test.id)} ⏲ ${test.duration / 1000 + 's'} ${chalk.red('⬆')} ${test.bytesSent} bytes ${chalk.green('⬇')} ${test.bytesReceived} bytes`)
+  console.log(`${(test.passed ? chalk.bgGreenBright(' PASS ') : chalk.bgRedBright(' FAIL '))} ${chalk.bold(test.name || test.id)} ⏲ ${test.duration / 1000 + 's'} ${chalk.magenta('⬆')} ${test.bytesSent} bytes ${chalk.cyan('⬇')} ${test.bytesReceived} bytes`)
   if (!test.passed || verbose) {
     renderStepSummary(test.steps)
     test.steps.forEach(step => renderStep(step, { verbose }))


### PR DESCRIPTION
For the same reason as in #221, I think it's better to avoid red and green for transferred data arrows. This PR changes it to magenta and cyan:

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-05-21 at 19 10 33](https://github.com/stepci/stepci/assets/37386490/f8965a51-f31c-4516-84ff-084bfd1eb9b2) | ![Screenshot 2024-05-21 at 19 11 03](https://github.com/stepci/stepci/assets/37386490/23a8208d-fdde-4f07-b09e-f5dd8ebf4f14) |